### PR TITLE
block at the bottom of the "await" stack instead of the top. 

### DIFF
--- a/ZocBuild.Database/Util/DbCommandExtensions.cs
+++ b/ZocBuild.Database/Util/DbCommandExtensions.cs
@@ -30,7 +30,9 @@ namespace ZocBuild.Database.Util
             if (sqlCommand != null)
             {
                 var asyncResult = sqlCommand.BeginExecuteNonQuery();
-                return await Task.Factory.FromAsync<int>(asyncResult, sqlCommand.EndExecuteNonQuery);
+                // TODO - DAC figure out what is wrong here and document or fix it.
+                var task = Task.Factory.FromAsync<int>(asyncResult, sqlCommand.EndExecuteNonQuery);
+                return task.Result;
             }
             else
             {


### PR DESCRIPTION
There is a problem in the scout code, which is worked-around in this PR.
A final fix will probably require more investagation.

The symptom: The task that is passed up the call stack does not block, e.g. here:

https://github.com/ZocDoc/Scout/blob/master/Scout.Common/Actions/DatabaseObjects/Wrappers/DatabaseWrapper.cs#L55

Experimentally, if the code calls "Wait()" or "Result", down at the bottom of the call stack (in `ExecuteNonQueryAsync`), it will (correctly) block.

@ZocDoc/coreinfrastructure 
