### PR TITLE
back out over-cautious async workaround

### DIFF
--- a/ZocBuild.Database/Util/DbCommandExtensions.cs
+++ b/ZocBuild.Database/Util/DbCommandExtensions.cs
@@ -36,9 +36,7 @@ namespace ZocBuild.Database.Util
             {
 #if NET_40
                 var asyncResult = sqlCommand.BeginExecuteNonQuery();
-                // TODO - DAC figure out what is wrong here and document or fix it.
-                var task = Task.Factory.FromAsync<int>(asyncResult, sqlCommand.EndExecuteNonQuery);
-                return task.Result;
+                return await Task.Factory.FromAsync<int>(asyncResult, sqlCommand.EndExecuteNonQuery);
 #else
                 return await sqlCommand.ExecuteNonQueryAsync();
 #endif


### PR DESCRIPTION
This workaround is in fact not needed. The strange behavior that I saw when investigating https://zocdoc.atlassian.net/browse/INFRA-2572 was spurious
(`System.Console.WriteLine` was not acting hread-safe. who knew?)
@ZocDoc/coreinfrastructure 